### PR TITLE
Set max window width to 120 columns

### DIFF
--- a/lua/rovo-dev/terminal.lua
+++ b/lua/rovo-dev/terminal.lua
@@ -5,9 +5,9 @@ local M = {}
 local function calc_width(config)
   local w = config.terminal.width
   if type(w) == 'number' and w > 0 and w < 1 then
-    return math.max(20, math.floor(vim.o.columns * w))
+    return math.min(120, math.floor(vim.o.columns * w))
   end
-  return math.max(20, w or 40)
+  return math.min(120, w or 40)
 end
 
 local function place_split(side)


### PR DESCRIPTION
120 columns is the maximum width that the Rovo Dev chat box can expand to. After that, there is just empty space.

# Pull Request

## Description

Fixes the maximum width of the Rovo Dev terminal window to 120 columns. The Rovo Dev chat box can't be wider than 120 columns. Making the window any larger is simply wasting space. A user might have width set to `0.33` which is less than 120 columns on a small monitor but greater than 120 on a larger external monitor. This ensures that on the large monitor, the window will fill up as much space as it can without wasting space.

## Type of Change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

Please check all that apply:

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested with the actual Rovo Dev CLI tool
- [X] I have tested in different environments (if applicable)

## Screenshots (if applicable)

**Before with 0.33 width on ultrawide monitor**

<img width="7044" height="2992" alt="Screenshot 2025-09-18 at 1 51 19 PM" src="https://github.com/user-attachments/assets/8f535d4f-e1b7-457b-8b25-faba1ca81d00" />

**After with 0.33 width on ultrawide monitor**

<img width="7044" height="2992" alt="Screenshot 2025-09-18 at 1 50 50 PM" src="https://github.com/user-attachments/assets/cd2ddd2d-2d52-4ebd-8a69-bf8a69f29c85" />

## Additional Notes

Add any other context about the PR here.
