### PR TITLE
fix spam notifications on deleted files

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,66 +2,91 @@
 
 std = {
   globals = {
-    "vim",
-    "table",
-    "string",
-    "math",
-    "os",
-    "io",
+    'vim',
+    'table',
+    'string',
+    'math',
+    'os',
+    'io',
+    'package',
   },
   read_globals = {
-    "jit",
-    "require",
-    "pcall",
-    "type",
-    "ipairs",
-    "pairs",
-    "tostring",
-    "tonumber",
-    "error",
-    "assert",
-    "_VERSION",
+    'jit',
+    'require',
+    'pcall',
+    'type',
+    'ipairs',
+    'pairs',
+    'tostring',
+    'tonumber',
+    'error',
+    'assert',
+    '_VERSION',
   },
 }
 
 -- Patterns for files to exclude
 exclude_files = {
-  ".luarocks/*",
-  "lua/plenary/*",
-  "tests/plenary/*",
+  '.luarocks/*',
+  'lua/plenary/*',
+  'tests/plenary/*',
 }
 
 -- Special configuration for scripts
-files["scripts/**/*.lua"] = {
+files['scripts/**/*.lua'] = {
   globals = {
-    "print", "arg",
+    'print',
+    'arg',
   },
 }
 
 -- Special configuration for test files
-files["tests/**/*.lua"] = {
+files['tests/**/*.lua'] = {
   -- Allow common globals used in testing
   globals = {
     -- Common testing globals
-    "describe", "it", "before_each", "after_each", "teardown", "pending", "spy", "stub", "mock",
+    'describe',
+    'it',
+    'before_each',
+    'after_each',
+    'teardown',
+    'pending',
+    'spy',
+    'stub',
+    'mock',
     -- Lua standard utilities used in tests
-    "print", "dofile",
+    'print',
+    'dofile',
     -- Test helpers
-    "test", "expect",
+    'test',
+    'expect',
     -- Global test state (allow modification)
-    "_G",
+    '_G',
   },
 
   -- Define fields for assert from luassert
   read_globals = {
     assert = {
       fields = {
-        "is_true", "is_false", "is_nil", "is_not_nil", "equals",
-        "same", "near", "matches", "has_error",
-        "truthy", "falsy", "has", "has_no", "is_string", "is_number",
-        "is_function", "is_table"
-      }
-    }
+        'is_true',
+        'is_false',
+        'is_nil',
+        'is_not_nil',
+        'equals',
+        'same',
+        'near',
+        'matches',
+        'has_error',
+        'truthy',
+        'falsy',
+        'has',
+        'has_no',
+        'is_string',
+        'is_number',
+        'is_function',
+        'is_table',
+      },
+    },
   },
 
   -- For test files only, ignore unused arguments as they're often used for mock callbacks
@@ -87,6 +112,6 @@ max_line_length = 120
 max_cyclomatic_complexity = 20
 
 -- Override settings for specific files
-files["lua/rovo-dev/config.lua"] = {
+files['lua/rovo-dev/config.lua'] = {
   max_cyclomatic_complexity = 30, -- The validate_config function has high complexity due to many validation checks
 }


### PR DESCRIPTION
# Pull Request

## Description

Buffers containing files that were deleted externally are spammed with notifications that the file has been modified. These changes make it so that these buffers get a single warning notification that the file has been deleted.

## Type of Change

Please check the options that are relevant:

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Checklist

Please check all that apply:

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested with the actual Rovo Dev CLI tool
- [X] I have tested in different environments (if applicable)

## Screenshots (if applicable)

**Before**

<img width="7044" height="2992" alt="Screenshot 2025-09-18 at 2 25 37 PM" src="https://github.com/user-attachments/assets/a2dad6de-9341-418f-9eb5-6ab4231c926f" />

**After**

<img width="7044" height="2992" alt="Screenshot 2025-09-18 at 2 26 15 PM" src="https://github.com/user-attachments/assets/a7f94169-3e85-45d5-881e-9b6a00f80272" />

## Additional Notes

Add any other context about the PR here.
